### PR TITLE
fix: add missing eqeqeq linting rule

### DIFF
--- a/angular.js
+++ b/angular.js
@@ -28,7 +28,6 @@ module.exports = {
     ],
     '@angular-eslint/no-output-native': 'error',
     '@angular-eslint/use-lifecycle-interface': 'error',
-    eqeqeq: 'error',
     '@angular-eslint/template/eqeqeq': 'error',
     // CYPRESS RULES
     'cypress/no-force': 'error',

--- a/angular.js
+++ b/angular.js
@@ -28,6 +28,8 @@ module.exports = {
     ],
     '@angular-eslint/no-output-native': 'error',
     '@angular-eslint/use-lifecycle-interface': 'error',
+    eqeqeq: 'error',
+    '@angular-eslint/template/eqeqeq': 'error',
     // CYPRESS RULES
     'cypress/no-force': 'error',
     'cypress/no-pause': 'error',


### PR DESCRIPTION
## Purpose

Add `"@angular-eslint/template/eqeqeq": "error"` to the linting rules
