### PR TITLE
Fix/remove eqeqeq

### DIFF
--- a/angular.js
+++ b/angular.js
@@ -28,7 +28,6 @@ module.exports = {
     ],
     '@angular-eslint/no-output-native': 'error',
     '@angular-eslint/use-lifecycle-interface': 'error',
-    '@angular-eslint/template/eqeqeq': 'error',
     // CYPRESS RULES
     'cypress/no-force': 'error',
     'cypress/no-pause': 'error',


### PR DESCRIPTION
Removed  '@angular-eslint/template/eqeqeq': 'error', from angular.js
