### PR TITLE
fix: moved peerdependencies to regular dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,30 +20,20 @@
   },
   "homepage": "https://github.com/AES-Outreach/eslint-config-outstem#readme",
   "packageManager": "yarn@3.3.1",
-  "peerDependencies": {
-    "@angular-eslint/eslint-plugin": "*",
-    "@angular-eslint/eslint-plugin-template": "*",
-    "@typescript-eslint/eslint-plugin": "*",
-    "eslint-plugin-eslint-comments": "*",
-    "eslint-plugin-import": "*",
-    "eslint-plugin-jsdoc": "*",
-    "eslint-plugin-mocha": "*",
-    "eslint-plugin-no-only-tests": "*",
-    "eslint-plugin-prefer-arrow": "*",
-    "eslint-plugin-unused-imports": "*"
-  },
-  "peerDependenciesMeta": {
-    "@angular-eslint/eslint-plugin": {
-      "optional": true
-    },
-    "@angular-eslint/eslint-plugin-template": {
-      "optional": true
-    }
-  },
   "dependencies": {
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-react": "^7.33.2",
-    "eslint-plugin-react-hooks": "^4.6.0"
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "@angular-eslint/eslint-plugin": "^17.3.0",
+    "@angular-eslint/eslint-plugin-template": "^17.3.0",
+    "@typescript-eslint/eslint-plugin": "^7.2.0",
+    "eslint-plugin-eslint-comments": "^3.2.0",
+    "eslint-plugin-import": "2.25.2",
+    "eslint-plugin-jsdoc": "30.7.6",
+    "eslint-plugin-mocha": "*",
+    "eslint-plugin-no-only-tests": "^2.6.0",
+    "eslint-plugin-prefer-arrow": "1.2.2",
+    "eslint-plugin-unused-imports": "^1.1.5"
   },
   "devDependencies": {
     "eslint": "^8.33.0",


### PR DESCRIPTION
##Purpose

This PR moved all the peerdependencies to regular dependencies as now in eslint it is not required to add all the plugins as peerdependencies. This will help in dependency maintenance.