### PR TITLE
Fix:(#5730) add new rule for self-closing tags to angular.js file

### DIFF
--- a/angular.js
+++ b/angular.js
@@ -45,6 +45,8 @@ module.exports = {
     ],
     '@angular-eslint/no-output-native': 'error',
     '@angular-eslint/use-lifecycle-interface': 'error',
+    '@angular-eslint/template/prefer-self-closing-tags': ['error'],
+
     // CYPRESS RULES
     'cypress/no-force': 'error',
     'cypress/no-pause': 'error',


### PR DESCRIPTION
##Purpose

This PR added a new rule for self-closing tags in the `angular.js` for eslint.