### PR TITLE
feat: add no-warning-comments rule

### DIFF
--- a/base.js
+++ b/base.js
@@ -18,4 +18,12 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     'plugin:eslint-comments/recommended',
   ],
+  rules: {
+    'no-warning-comments': [
+      'error',
+      {
+        terms: ['DEBUG'],
+      },
+    ],
+  },
 };

--- a/base.js
+++ b/base.js
@@ -18,12 +18,4 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     'plugin:eslint-comments/recommended',
   ],
-  rules: {
-    'no-warning-comments': [
-      'error',
-      {
-        terms: ['DEBUG'],
-      },
-    ],
-  },
 };

--- a/overrides.js
+++ b/overrides.js
@@ -18,6 +18,12 @@ module.exports = {
     'jsdoc/newline-after-description': 'off',
     'no-var': 'error',
     'no-shadow': 'off', // This rule must be disabled because it conflicts with @typescript-eslint/no-shadow
+    'no-warning-comments': [
+      'error',
+      {
+        terms: ['DEBUG'],
+      },
+    ],
 
     // TODO: this one isn't in everything why??
     // Import rules linting options


### PR DESCRIPTION
This PR adds a `no-warning-comment` rule that will trigger for comments containing the term `DEBUG`. This is to mark debug code.