### PR TITLE
clean: remove dead `ban-types` rule

### DIFF
--- a/overrides.js
+++ b/overrides.js
@@ -59,7 +59,6 @@ module.exports = {
       },
     ],
     '@typescript-eslint/no-non-null-assertion': 'error',
-    '@typescript-eslint/ban-types': 'error',
     // TODO: do we want this one??
     '@typescript-eslint/member-ordering': 'off',
     '@typescript-eslint/consistent-type-assertions': 'error',


### PR DESCRIPTION
## Purpose
Remove the now dead `ban-types` rule from the config so that this works with typescript-eslint v8.

The `ban-types` rule was replaced by a few rules and those rules are in the recommended ruleset so we get them automatically because that recommended is already extended here. The only catch is that if one of our repos has an outdated version of `@typescript-eslint/eslint-plugin` then they won't get the new rules and the old rule will have been removed from our config. The problem is we can't use the config if the version of `@typescript-eslint/eslint-plugin` is up to date while we have this rule in place