### PR TITLE
fix: move prettier eslint config back to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "eslint-plugin-mocha": "*",
     "eslint-plugin-no-only-tests": "*",
     "eslint-plugin-prefer-arrow": "*",
-    "eslint-config-prettier": "*",
     "eslint-plugin-react": "*",
     "eslint-plugin-react-hooks": "*",
     "eslint-plugin-unused-imports": "*"
@@ -50,6 +49,7 @@
     }
   },
   "dependencies": {
+    "eslint-config-prettier": "^8.3.0"
   },
   "devDependencies": {
     "eslint": "^8.33.0",


### PR DESCRIPTION
## Purpose
The eslint prettier config slipped in with the plugins that I was moving and I didn't notice it was a config rather than a plugin and therefore should stay in the deps.